### PR TITLE
Start services via SSH

### DIFF
--- a/modules/ignition-hdfs-datanode/main.tf
+++ b/modules/ignition-hdfs-datanode/main.tf
@@ -9,6 +9,6 @@ data "template_file" "hdfs-datanode" {
 
 data "ignition_systemd_unit" "hdfs-datanode" {
   name    = "hdfs-datanode.service"
-  enabled = true
+  enabled = false
   content = "${data.template_file.hdfs-datanode.rendered}"
 }

--- a/modules/ignition-hdfs-namenode-fmt/main.tf
+++ b/modules/ignition-hdfs-namenode-fmt/main.tf
@@ -8,6 +8,6 @@ data "template_file" "hdfs-namenode-fmt" {
 
 data "ignition_systemd_unit" "hdfs-namenode-fmt" {
   name    = "hdfs-namenode-fmt.service"
-  enabled = true
+  enabled = false
   content = "${data.template_file.hdfs-namenode-fmt.rendered}"
 }

--- a/modules/ignition-hdfs-namenode/main.tf
+++ b/modules/ignition-hdfs-namenode/main.tf
@@ -8,6 +8,6 @@ data "template_file" "hdfs-namenode" {
 
 data "ignition_systemd_unit" "hdfs-namenode" {
   name    = "hdfs-namenode.service"
-  enabled = true
+  enabled = false
   content = "${data.template_file.hdfs-namenode.rendered}"
 }

--- a/modules/ignition-nvidia4coreos/main.tf
+++ b/modules/ignition-nvidia4coreos/main.tf
@@ -8,6 +8,6 @@ data "template_file" "nvidia4coreos" {
 
 data "ignition_systemd_unit" "nvidia4coreos" {
   name    = "nvidia4coreos.service"
-  enabled = true
+  enabled = false
   content = "${data.template_file.nvidia4coreos.rendered}"
 }

--- a/modules/ignition-proxy/main.tf
+++ b/modules/ignition-proxy/main.tf
@@ -8,6 +8,6 @@ data "template_file" "spark-ui-proxy" {
 
 data "ignition_systemd_unit" "spark-ui-proxy" {
   name    = "spark-ui-proxy.service"
-  enabled = true
+  enabled = false
   content = "${data.template_file.spark-ui-proxy.rendered}"
 }

--- a/modules/ignition-spark-master/main.tf
+++ b/modules/ignition-spark-master/main.tf
@@ -8,6 +8,6 @@ data "template_file" "spark-master" {
 
 data "ignition_systemd_unit" "spark-master" {
   name    = "spark-master.service"
-  enabled = true
+  enabled = false
   content = "${data.template_file.spark-master.rendered}"
 }

--- a/modules/ignition-spark-worker/main.tf
+++ b/modules/ignition-spark-worker/main.tf
@@ -9,6 +9,6 @@ data "template_file" "spark-worker" {
 
 data "ignition_systemd_unit" "spark-worker" {
   name    = "spark-worker.service"
-  enabled = true
+  enabled = false
   content = "${data.template_file.spark-worker.rendered}"
 }

--- a/modules/ignition-zeppelin/main.tf
+++ b/modules/ignition-zeppelin/main.tf
@@ -8,6 +8,6 @@ data "template_file" "zeppelin" {
 
 data "ignition_systemd_unit" "zeppelin" {
   name    = "zeppelin.service"
-  enabled = true
+  enabled = false
   content = "${data.template_file.zeppelin.rendered}"
 }


### PR DESCRIPTION
## Change content and motivation
Start services via SSH. This makes waiting simpler, and `/etc/hosts` setup more robust.
