### PR TITLE
Mount /var/tmp to Spark containers

### DIFF
--- a/modules/ignition-spark-master/spark-master.service
+++ b/modules/ignition-spark-master/spark-master.service
@@ -9,6 +9,7 @@ ExecStartPre=-/usr/bin/docker rm spark-master
 ExecStart=/usr/bin/bash -c "/usr/bin/docker run \
                         --volume /var/run/docker.sock:/var/run/docker.sock \
                         --volume /tmp:/tmp \
+                        --volume /var/tmp:/var/tmp \
                         --volume /etc/hadoop/:/etc/hadoop \
                         --env HADOOP_CONF_DIR=/etc/hadoop \
                         --env SPARK_MASTER_HOST=$(hostname) \

--- a/modules/ignition-spark-worker/spark-worker.service
+++ b/modules/ignition-spark-worker/spark-worker.service
@@ -9,6 +9,7 @@ ExecStartPre=-/usr/bin/docker rm spark-worker
 ExecStart=/usr/bin/bash -c "/usr/bin/docker run \
                         --volume /var/run/docker.sock:/var/run/docker.sock \
                         --volume /tmp:/tmp \
+                        --volume /var/tmp:/var/tmp \
                         --volume /etc/hadoop/:/etc/hadoop \
                         --env HADOOP_CONF_DIR=/etc/hadoop \
                         --env SPARK_LOCAL_DIRS=/var/tmp \

--- a/modules/ignition-zeppelin/zeppelin.service
+++ b/modules/ignition-zeppelin/zeppelin.service
@@ -9,6 +9,7 @@ ExecStartPre=-/usr/bin/docker rm zeppelin
 ExecStart=/usr/bin/bash -c "/usr/bin/docker run \
                         --volume /var/run/docker.sock:/var/run/docker.sock \
                         --volume /tmp:/tmp \
+                        --volume /var/tmp:/var/tmp \
                         --volume /var/zeppelin-notebooks:/notebooks \
                         --volume /etc/hadoop/:/etc/hadoop \
                         --volume /etc/zeppelin/zeppelin-site.xml:/tmp/zeppelin-site.xml \


### PR DESCRIPTION
## Change content and motivation
Mount /var/tmp to Spark containers. Adding mapped temporary directory that is not a `tmpfs` may be beneficial for large temporary files.
