### PR TITLE
Map volume mount in Spark worker

### DIFF
--- a/modules/ignition-spark-worker/spark-worker.service
+++ b/modules/ignition-spark-worker/spark-worker.service
@@ -11,6 +11,7 @@ ExecStart=/usr/bin/bash -c "/usr/bin/docker run \
                         --volume /tmp:/tmp \
                         --volume /var/tmp:/var/tmp \
                         --volume /etc/hadoop/:/etc/hadoop \
+                        --volume /var/tmp:/var/tmp \
                         --env HADOOP_CONF_DIR=/etc/hadoop \
                         --env SPARK_LOCAL_DIRS=/var/tmp \
                         --network host \


### PR DESCRIPTION
## Change content and motivation
Map volume mount in Spark worker. Can be useful to write large temorary data.
